### PR TITLE
여러 UI 요소 수정

### DIFF
--- a/PeakConnect/PeakConnect/App/SceneDelegate.swift
+++ b/PeakConnect/PeakConnect/App/SceneDelegate.swift
@@ -16,8 +16,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
 
-        let mainVC = UINavigationController(rootViewController: MainViewController()) 
+        let mainVC = UINavigationController(rootViewController: MainViewController())
+        mainVC.navigationBar.tintColor = .white
         let historyVC = UINavigationController(rootViewController: HistoryViewController())
+        historyVC.navigationBar.tintColor = .white
         let tabBarController = UITabBarController()
         tabBarController.setViewControllers([mainVC, historyVC], animated: false)
         

--- a/PeakConnect/PeakConnect/Source/Common/UserDefaults+Extension.swift
+++ b/PeakConnect/PeakConnect/Source/Common/UserDefaults+Extension.swift
@@ -12,6 +12,7 @@ extension UserDefaults {
     private enum Keys {
         static let isBegginer = "isBegginer"
         static let uuid = "uuid"
+        static let companyName = "companyName"
     }
     
     var isBegginer: Bool {
@@ -29,6 +30,15 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: Keys.uuid)
+        }
+    }
+    
+    var companyName: String {
+        get {
+            string(forKey: Keys.companyName) ?? ""
+        }
+        set {
+            set(newValue, forKey: Keys.companyName)
         }
     }
 }

--- a/PeakConnect/PeakConnect/Source/View/Feature/CreateCompany/CreateCompanyView.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/CreateCompany/CreateCompanyView.swift
@@ -194,4 +194,17 @@ extension CreateCompanyView {
             make.top.equalTo(safeAreaLayoutGuide.snp.top).inset(20)
         }
     }
+    
+    func overCount() {
+        companyDescriptionTextView.layer.borderColor = UIColor.red.cgColor
+        companyDescriptionTextView.layer.borderWidth = 1
+        companyDescriptionCountLabel.textColor = .red
+        createButton.isEnabled = false
+    }
+    
+    func underCount() {
+        companyDescriptionTextView.layer.borderColor = .none
+        companyDescriptionCountLabel.textColor = .grayssss
+        createButton.isEnabled = true
+    }
 }

--- a/PeakConnect/PeakConnect/Source/View/Feature/CreateCompany/CreateCompanyViewController.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/CreateCompany/CreateCompanyViewController.swift
@@ -59,8 +59,13 @@ extension CreateCompanyViewController {
         let output = createCompanyViewModel.transform(input: input)
         
         output.companyDescriptionCount
-            .drive(with: self, onNext: { owner, text in
-                owner.createCompanyView.companyDescriptionCountLabel.text = text
+            .drive(with: self, onNext: { owner, count in
+                owner.createCompanyView.companyDescriptionCountLabel.text = "\(count)/100"
+                if count > 100 {
+                    owner.createCompanyView.overCount()
+                } else {
+                    owner.createCompanyView.underCount()
+                }
             })
             .disposed(by: disposeBag)
         
@@ -75,7 +80,6 @@ extension CreateCompanyViewController {
                 guard let company = company else { return }
                 owner.createCompanyView.setupEditMode(company)
                 owner.navigation()
-                print("test")
             })
             .disposed(by: disposeBag)
     }

--- a/PeakConnect/PeakConnect/Source/View/Feature/CreateCompany/CreateCompanyViewController.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/CreateCompany/CreateCompanyViewController.swift
@@ -98,7 +98,6 @@ extension CreateCompanyViewController {
         let titleLabel = UILabel()
         titleLabel.text = "회사 정보 수정"
         titleLabel.font = UIFont(name: "Pretendard-SemiBold", size: 18)
-        titleLabel.textColor = .label
         navigationItem.titleView = titleLabel
 
     }

--- a/PeakConnect/PeakConnect/Source/View/Feature/CreateCompany/CreateCompanyViewModel.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/CreateCompany/CreateCompanyViewModel.swift
@@ -101,6 +101,7 @@ extension CreateCompanyViewModel {
             switch result {
             case .success(let uuid):
                 UserDefaults.standard.isBegginer = true
+                UserDefaults.standard.companyName = self.companyName
                 self.completeRelay.accept(mode)
                 guard let uuid = uuid else {
                     return

--- a/PeakConnect/PeakConnect/Source/View/Feature/CreateCompany/CreateCompanyViewModel.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/CreateCompany/CreateCompanyViewModel.swift
@@ -17,7 +17,7 @@ enum CreateCompanyMode {
 
 final class CreateCompanyViewModel {
     
-    private var countRelay = BehaviorRelay<String>(value: "0/100")
+    private var countRelay = BehaviorRelay<Int>(value: 0)
     private var completeRelay = PublishRelay<CreateCompanyMode>()
     private var companyRelay = BehaviorRelay<Company?>(value: nil)
     
@@ -47,7 +47,7 @@ extension CreateCompanyViewModel {
     }
     
     struct Output {
-        let companyDescriptionCount: Driver<String>
+        let companyDescriptionCount: Driver<Int>
         let complete: Driver<CreateCompanyMode>
         let company: Driver<Company?>
     }
@@ -64,7 +64,7 @@ extension CreateCompanyViewModel {
             .withUnretained(self)
             .subscribe(onNext: { owner, description in
                 owner.companyDescription = description
-                owner.countRelay.accept("\(description.count)/\(100)")
+                owner.countRelay.accept(description.count)
             })
             .disposed(by: disposeBag)
         

--- a/PeakConnect/PeakConnect/Source/View/Feature/History/HistoryView.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/History/HistoryView.swift
@@ -26,6 +26,14 @@ class HistoryView: UIView {
         $0.showsVerticalScrollIndicator = false
         $0.register(HistoryViewCollectionViewCell.self, forCellWithReuseIdentifier: HistoryViewCollectionViewCell.id)
     }
+    
+    let noHistoryLabel = UILabel().then {
+        $0.text = "리드 추천 히스토리가 없습니다."
+        $0.numberOfLines = 2
+        $0.font = UIFont(name: "Pretendard-Regular", size: 20)
+        $0.textColor = .disabled
+        $0.isHidden = true
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -43,7 +51,8 @@ extension HistoryView {
         [
             topLogoImageView,
             titleLabel,
-            colletionView
+            colletionView,
+            noHistoryLabel
         ].forEach {
             addSubview($0)
         }
@@ -64,6 +73,10 @@ extension HistoryView {
             make.top.equalTo(titleLabel.snp.bottom).offset(10)
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(20)
+        }
+        
+        noHistoryLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
         }
 
     }

--- a/PeakConnect/PeakConnect/Source/View/Feature/History/HistoryViewCollectionViewCell.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/History/HistoryViewCollectionViewCell.swift
@@ -138,7 +138,10 @@ extension HistoryViewCollectionViewCell {
         listTextLabel.text = history.leads
         countTextLabel.text = "총 \(history.count)개 업체"
         
-        if let date = ISO8601DateFormatter().date(from: history.createdAt) {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        
+        if let date = isoFormatter.date(from: history.createdAt) {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy.MM.dd"
             let formattedDate = formatter.string(from: date)

--- a/PeakConnect/PeakConnect/Source/View/Feature/History/HistoryViewController.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/History/HistoryViewController.swift
@@ -45,6 +45,12 @@ extension HistoryViewController {
         let output = historyViewModel.transform(input: input)
         
         output.history
+            .skip(1)
+            .do(onNext: { [weak self] history in
+                guard let self = self else { return }
+                let historyIsEmpty = history.isEmpty ? false : true
+                self.historyView.noHistoryLabel.isHidden = historyIsEmpty
+            })
             .drive(historyView.colletionView.rx.items(
                 cellIdentifier: HistoryViewCollectionViewCell.id,
                 cellType: HistoryViewCollectionViewCell.self)) { row, element, cell in

--- a/PeakConnect/PeakConnect/Source/View/Feature/History/HistoryViewController.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/History/HistoryViewController.swift
@@ -28,6 +28,7 @@ class HistoryViewController: UIViewController, UICollectionViewDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.navigationBar.isHidden = true
+        tabBarController?.tabBar.isHidden = false
     }
     
 }

--- a/PeakConnect/PeakConnect/Source/View/Feature/HistoryResult/HistoryResultCollectionViewCell.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/HistoryResult/HistoryResultCollectionViewCell.swift
@@ -51,7 +51,7 @@ extension HistoryResultCollectionViewCell {
         }
         
         adressNameLabel.snp.makeConstraints { make in
-            make.bottom.leading.equalToSuperview().inset(20)
+            make.bottom.leading.trailing.equalToSuperview().inset(20)
         }
     }
 }

--- a/PeakConnect/PeakConnect/Source/View/Feature/HistoryResult/HistoryResultViewController.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/HistoryResult/HistoryResultViewController.swift
@@ -40,7 +40,6 @@ class HistoryResultViewController: UIViewController {
         let titleLabel = UILabel()
         titleLabel.text = "리드 추천 결과"
         titleLabel.font = UIFont(name: "Pretendard-SemiBold", size: 18)
-        titleLabel.textColor = .label
         navigationItem.titleView = titleLabel
         tabBarController?.tabBar.isHidden = true
         }

--- a/PeakConnect/PeakConnect/Source/View/Feature/HistoryResult/HistoryResultViewController.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/HistoryResult/HistoryResultViewController.swift
@@ -42,6 +42,7 @@ class HistoryResultViewController: UIViewController {
         titleLabel.font = UIFont(name: "Pretendard-SemiBold", size: 18)
         titleLabel.textColor = .label
         navigationItem.titleView = titleLabel
+        tabBarController?.tabBar.isHidden = true
         }
 }
 

--- a/PeakConnect/PeakConnect/Source/View/Feature/LeadDetail/DetatilView.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/LeadDetail/DetatilView.swift
@@ -77,6 +77,7 @@ class DetailView: UIView {
             make.centerY.equalToSuperview()
             make.leading.equalTo(text.snp.trailing).offset(5)
             make.size.equalTo(12)
+            make.trailing.lessThanOrEqualToSuperview()
         }
     }
 }

--- a/PeakConnect/PeakConnect/Source/View/Feature/LeadDetail/LeadDeatilView.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/LeadDetail/LeadDeatilView.swift
@@ -11,6 +11,12 @@ import Then
 
 class LeadDeatilView: UIView {
     
+    private let scrollView = UIScrollView().then {
+        $0.showsVerticalScrollIndicator = false
+    }
+    
+    private let contentView = UIView()
+    
     private let companyInformationView = LeadComponentsView().then {
         $0.backgroundColor = .text
         $0.layer.cornerRadius = 24
@@ -94,12 +100,29 @@ extension LeadDeatilView {
     
     private func setupUI() {
         [
-            companyInformationView,
-            detailView,
-            recommendView,
+            scrollView,
             toastView
         ].forEach {
             addSubview($0)
+        }
+        
+        scrollView.addSubview(contentView)
+        
+        [
+            companyInformationView,
+            detailView,
+            recommendView
+        ].forEach {
+            contentView.addSubview($0)
+        }
+        
+        scrollView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.width.equalToSuperview()
         }
         
         companyInformationView.topView.addSubview(companyInformationLabel)
@@ -129,7 +152,7 @@ extension LeadDeatilView {
         }
         
         companyInformationView.snp.makeConstraints { make in
-            make.top.equalTo(safeAreaLayoutGuide.snp.top).inset(20)
+            make.top.equalToSuperview().inset(20)
             make.horizontalEdges.equalToSuperview().inset(20)
             make.bottom.equalTo(companyInformationDetailLabel.snp.bottom).offset(20)
         }
@@ -152,6 +175,7 @@ extension LeadDeatilView {
             make.top.equalTo(detailView.snp.bottom).offset(20)
             make.horizontalEdges.equalToSuperview().inset(20)
             make.bottom.equalTo(recommendDetailLabel.snp.bottom).offset(20)
+            make.bottom.equalToSuperview()
         }
         
         toastView.snp.makeConstraints { make in

--- a/PeakConnect/PeakConnect/Source/View/Feature/LeadDetail/LeadDeatilView.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/LeadDetail/LeadDeatilView.swift
@@ -231,16 +231,16 @@ extension LeadDeatilView {
 extension LeadDeatilView {
     
     func configure(_ result: LeadInfo) {
-        companyInformationDetailLabel.text = result.summary
         nameLabel.text = result.ceo_name
         locationView.configure(text: result.address)
         siteView.configure(text: result.website)
         yearView.configure(text: "\(result.year_founded)")
+        
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = 6
 
         let recommendDetailAttributedString = NSAttributedString(
-            string: result.summary,
+            string: result.match_reason,
             attributes: [
                 .font: UIFont(name: "Pretendard-Regular", size: 14) as Any,
                 .paragraphStyle: paragraphStyle
@@ -248,7 +248,7 @@ extension LeadDeatilView {
         )
         
         let companyAttributedString = NSAttributedString(
-            string: result.match_reason,
+            string: result.summary,
             attributes: [
                 .font: UIFont(name: "Pretendard-Regular", size: 14) as Any,
                 .paragraphStyle: paragraphStyle

--- a/PeakConnect/PeakConnect/Source/View/Feature/LeadDetail/LeadDeatilView.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/LeadDetail/LeadDeatilView.swift
@@ -34,7 +34,6 @@ class LeadDeatilView: UIView {
     
     private let companyInformationDetailLabel = UILabel().then {
         $0.font = UIFont(name: "Pretendard-Regular", size: 14)
-        $0.textAlignment = .justified
         $0.numberOfLines = 0
     }
     
@@ -75,7 +74,6 @@ class LeadDeatilView: UIView {
 
     private let recommendDetailLabel = UILabel().then {
         $0.font = UIFont(name: "Pretendard-Regular", size: 14)
-        $0.textAlignment = .justified
         $0.numberOfLines = 0
     }
     
@@ -214,6 +212,26 @@ extension LeadDeatilView {
         locationView.configure(text: result.address)
         siteView.configure(text: result.website)
         yearView.configure(text: "\(result.year_founded)")
-        recommendDetailLabel.text = result.match_reason
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 6
+
+        let recommendDetailAttributedString = NSAttributedString(
+            string: result.summary,
+            attributes: [
+                .font: UIFont(name: "Pretendard-Regular", size: 14) as Any,
+                .paragraphStyle: paragraphStyle
+            ]
+        )
+        
+        let companyAttributedString = NSAttributedString(
+            string: result.match_reason,
+            attributes: [
+                .font: UIFont(name: "Pretendard-Regular", size: 14) as Any,
+                .paragraphStyle: paragraphStyle
+            ]
+        )
+        
+        recommendDetailLabel.attributedText = recommendDetailAttributedString
+        companyInformationDetailLabel.attributedText = companyAttributedString
     }
 }

--- a/PeakConnect/PeakConnect/Source/View/Feature/LeadDetail/LeadDeatilViewController.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/LeadDetail/LeadDeatilViewController.swift
@@ -75,7 +75,6 @@ extension LeadDeatilViewController {
         let titleLabel = UILabel()
         titleLabel.text = title
         titleLabel.font = UIFont(name: "Pretendard-SemiBold", size: 18)
-        titleLabel.textColor = .label
         navigationItem.titleView = titleLabel
     }
     

--- a/PeakConnect/PeakConnect/Source/View/Feature/Main/MainView.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/Main/MainView.swift
@@ -133,7 +133,7 @@ class MainView: UIView {
 
 extension MainView {
     
-    func setupData(company: Company) {
-        companyNameLabel.text = "\(company.name) 님"
+    func setupData(_ companyName: String) {
+        companyNameLabel.text = "\(companyName) 님"
     }
 }

--- a/PeakConnect/PeakConnect/Source/View/Feature/Main/MainViewController.swift
+++ b/PeakConnect/PeakConnect/Source/View/Feature/Main/MainViewController.swift
@@ -57,9 +57,9 @@ extension MainViewController {
             })
             .disposed(by: disposeBag)
         
-        output.company
-            .drive(with: self, onNext: { owner, company in
-                owner.mainView.setupData(company: company)
+        output.companyName
+            .drive(with: self, onNext: { owner, companyName in
+                owner.mainView.setupData(companyName)
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
## ✅ 작업 사항
- 회사 등록 화면에서 회사 소개 입력이 100자가 넘어갈 시 예외처리를 했습니다.
- 리드 상세 보기 화면에서 줄간격을 수정하고, 스크롤이 가능하게 수정했습니다. 
- 히스토리 화면에서 내역이 하나도 없을 경우 라벨을 보여주도록 했습니다.

## 👉 리뷰 포인트
- 메인화면 회사 이름 속도 로딩 개선을 했습니다.
  - pull 받고 처음 실행시 회사 이름 수정을 해주세요.

## 📸 스크린샷
![simulator_screenshot_E5AE6144-7430-4194-BF8A-948055BDBF32](https://github.com/user-attachments/assets/93b9f7c8-6aa8-4354-b37b-5f1b290dde8b)
![simulator_screenshot_84E87FC6-B10E-4165-9A97-BDA7A189A8DB](https://github.com/user-attachments/assets/350e9666-4341-40c3-8cd6-904839004324)
![Simulator Screenshot - iPhone 16 Pro - 2025-05-30 at 17 05 16](https://github.com/user-attachments/assets/6c196450-02c6-4f8f-9785-5f1f809d12fc)


## 😀 기타

